### PR TITLE
Implement mesh relay skeleton

### DIFF
--- a/pkg/sfu/mesh/receiver.go
+++ b/pkg/sfu/mesh/receiver.go
@@ -1,0 +1,59 @@
+package mesh
+
+import (
+	"sync"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/psrpc"
+)
+
+// Receiver consumes RTP/RTCP from a remote node via a psrpc stream.
+type Receiver struct {
+	stream psrpc.Stream[*RTPMessage, *RTCPMessage]
+	logger logger.Logger
+	mu     sync.Mutex
+
+	OnRTP  func(*rtp.Packet)
+	OnRTCP func([]rtcp.Packet)
+}
+
+func NewReceiver(stream psrpc.Stream[*RTPMessage, *RTCPMessage], l logger.Logger) *Receiver {
+	r := &Receiver{stream: stream, logger: l}
+	go r.read()
+	return r
+}
+
+func (r *Receiver) read() {
+	for msg := range r.stream.Channel() {
+		if msg.Packets != nil { // RTCP
+			pkts := make([]rtcp.Packet, 0, len(msg.Packets))
+			for _, b := range msg.Packets {
+				ps, err := rtcp.Unmarshal(b)
+				if err == nil {
+					pkts = append(pkts, ps...)
+				}
+			}
+			if r.OnRTCP != nil {
+				r.OnRTCP(pkts)
+			}
+			continue
+		}
+		if msg.Packet != nil {
+			pkt := &rtp.Packet{}
+			if err := pkt.Unmarshal(msg.Packet); err == nil {
+				if r.OnRTP != nil {
+					r.OnRTP(pkt)
+				}
+			}
+		}
+	}
+}
+
+func (r *Receiver) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stream.Close(nil)
+}

--- a/pkg/sfu/mesh/relay.go
+++ b/pkg/sfu/mesh/relay.go
@@ -1,0 +1,67 @@
+package mesh
+
+import (
+	"sync"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/psrpc"
+)
+
+// RTPMessage is a minimal wrapper for forwarding RTP packets via psrpc.
+type RTPMessage struct {
+	Packet []byte
+}
+
+// RTCPMessage wraps a batch of RTCP packets for forwarding.
+type RTCPMessage struct {
+	Packets [][]byte
+}
+
+// Relay forwards media to a remote SFU node using psrpc streams.
+type Relay struct {
+	stream psrpc.Stream[*RTPMessage, *RTCPMessage]
+	logger logger.Logger
+	mu     sync.Mutex
+}
+
+func NewRelay(stream psrpc.Stream[*RTPMessage, *RTCPMessage], l logger.Logger) *Relay {
+	return &Relay{stream: stream, logger: l}
+}
+
+// ForwardRTP forwards an RTP packet to the remote node.
+func (r *Relay) ForwardRTP(pkt *rtp.Packet) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	b, err := pkt.Marshal()
+	if err != nil {
+		return err
+	}
+	return r.stream.Send(&RTPMessage{Packet: b})
+}
+
+// ForwardRTCP forwards RTCP packets to the remote node.
+func (r *Relay) ForwardRTCP(pkts []rtcp.Packet) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	data := make([][]byte, 0, len(pkts))
+	for _, p := range pkts {
+		b, err := p.Marshal()
+		if err != nil {
+			return err
+		}
+		data = append(data, b)
+	}
+	return r.stream.Send(&RTCPMessage{Packets: data})
+}
+
+// Close terminates the underlying psrpc stream.
+func (r *Relay) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stream.Close(nil)
+}


### PR DESCRIPTION
## Summary
- stub out SFU mesh relay components for RTP/RTCP forwarding
- expose relay management hooks on `MediaTrack` and `Participant`
- begin wiring up `ForwardParticipant` in `RoomManager`