### PR TITLE
Add mesh router skeleton

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -229,6 +229,10 @@ keys:
 #   # number of messages to buffer before dropping
 #   buffer_size: 1000
 
+# Mesh networking between nodes (experimental)
+# mesh:
+#   enabled: true
+
 # customize audio level sensitivity
 # audio:
 #   # minimum level to be considered active, 0-127, where 0 is loudest

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	Region         string                   `yaml:"region,omitempty"`
 	SignalRelay    SignalRelayConfig        `yaml:"signal_relay,omitempty"`
 	PSRPC          rpc.PSRPCConfig          `yaml:"psrpc,omitempty"`
+	Mesh           MeshConfig               `yaml:"mesh,omitempty"`
 	// Deprecated: LogLevel is deprecated
 	LogLevel string        `yaml:"log_level,omitempty"`
 	Logging  LoggingConfig `yaml:"logging,omitempty"`
@@ -211,6 +212,10 @@ type NodeSelectorConfig struct {
 	CPULoadLimit float32        `yaml:"cpu_load_limit,omitempty"`
 	SysloadLimit float32        `yaml:"sysload_limit,omitempty"`
 	Regions      []RegionConfig `yaml:"regions,omitempty"`
+}
+
+type MeshConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 type SignalRelayConfig struct {
@@ -396,6 +401,7 @@ var DefaultConfig = Config{
 		ConnectAttempts:  3,
 	},
 	PSRPC:     rpc.DefaultPSRPCConfig,
+	Mesh:      MeshConfig{Enabled: false},
 	Keys:      map[string]string{},
 	Metric:    metric.DefaultMetricConfig,
 	WebHook:   webhook.DefaultWebHookConfig,

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -1,0 +1,51 @@
+package mesh
+
+import (
+	"sync"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+// NodeInfo describes a node participating in the mesh.
+type NodeInfo struct {
+	ID      livekit.NodeID
+	Address string
+}
+
+// Mesh provides a simple in-memory registry of nodes forming a mesh network.
+type Mesh struct {
+	mu    sync.RWMutex
+	nodes map[livekit.NodeID]*NodeInfo
+}
+
+// NewMesh returns an initialized Mesh instance.
+func NewMesh() *Mesh {
+	return &Mesh{
+		nodes: make(map[livekit.NodeID]*NodeInfo),
+	}
+}
+
+// AddNode registers a node with the mesh.
+func (m *Mesh) AddNode(id livekit.NodeID, address string) {
+	m.mu.Lock()
+	m.nodes[id] = &NodeInfo{ID: id, Address: address}
+	m.mu.Unlock()
+}
+
+// RemoveNode unregisters a node from the mesh.
+func (m *Mesh) RemoveNode(id livekit.NodeID) {
+	m.mu.Lock()
+	delete(m.nodes, id)
+	m.mu.Unlock()
+}
+
+// ListNodes returns a copy of the currently registered nodes.
+func (m *Mesh) ListNodes() []*NodeInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*NodeInfo, 0, len(m.nodes))
+	for _, n := range m.nodes {
+		out = append(out, &NodeInfo{ID: n.ID, Address: n.Address})
+	}
+	return out
+}

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -1,0 +1,15 @@
+package mesh
+
+import "testing"
+
+func TestMeshAddList(t *testing.T) {
+	m := NewMesh()
+	m.AddNode("node1", "addr1")
+	nodes := m.ListNodes()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if nodes[0].ID != "node1" || nodes[0].Address != "addr1" {
+		t.Fatalf("unexpected node data")
+	}
+}

--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/mesh"
 	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -164,11 +165,18 @@ func CreateRouter(
 	roomManagerClient RoomManagerClient,
 	kps rpc.KeepalivePubSub,
 	nodeStatsConfig config.NodeStatsConfig,
+	meshConfig config.MeshConfig,
+	meshNet *mesh.Mesh,
 ) Router {
 	lr := NewLocalRouter(node, signalClient, roomManagerClient, nodeStatsConfig)
 
 	if rc != nil {
 		return NewRedisRouter(lr, rc, kps)
+	}
+
+	if meshConfig.Enabled && meshNet != nil {
+		logger.Infow("using mesh routing")
+		return NewMeshRouter(lr, meshNet)
 	}
 
 	// local routing and store

--- a/pkg/routing/meshrouter.go
+++ b/pkg/routing/meshrouter.go
@@ -1,0 +1,40 @@
+package routing
+
+import (
+	"github.com/livekit/livekit-server/pkg/mesh"
+	"github.com/livekit/protocol/livekit"
+)
+
+// MeshRouter is a minimal router that registers nodes with a Mesh.
+type MeshRouter struct {
+	*LocalRouter
+	mesh *mesh.Mesh
+}
+
+var _ Router = (*MeshRouter)(nil)
+
+// NewMeshRouter creates a MeshRouter using the provided LocalRouter and mesh.
+func NewMeshRouter(lr *LocalRouter, m *mesh.Mesh) *MeshRouter {
+	return &MeshRouter{LocalRouter: lr, mesh: m}
+}
+
+func (r *MeshRouter) RegisterNode() error {
+	r.mesh.AddNode(r.currentNode.NodeID(), r.currentNode.NodeIP())
+	return r.LocalRouter.RegisterNode()
+}
+
+func (r *MeshRouter) UnregisterNode() error {
+	r.mesh.RemoveNode(r.currentNode.NodeID())
+	return r.LocalRouter.UnregisterNode()
+}
+
+func (r *MeshRouter) ListNodes() ([]*livekit.Node, error) {
+	infos := r.mesh.ListNodes()
+	nodes := make([]*livekit.Node, 0, len(infos)+1)
+	for _, inf := range infos {
+		nodes = append(nodes, &livekit.Node{Id: string(inf.ID), Ip: inf.Address})
+	}
+	lrNodes, _ := r.LocalRouter.ListNodes()
+	nodes = append(nodes, lrNodes...)
+	return nodes, nil
+}

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/livekit/livekit-server/pkg/agent"
 	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/mesh"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/telemetry"
@@ -52,6 +53,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		createWebhookNotifier,
 		createForwardStats,
 		getNodeStatsConfig,
+		getMeshConfig,
+		mesh.NewMesh,
 		routing.CreateRouter,
 		getLimitConf,
 		config.DefaultAPIConfig,
@@ -118,6 +121,8 @@ func InitializeRouter(conf *config.Config, currentNode routing.LocalNode) (routi
 		routing.NewRoomManagerClient,
 		rpc.NewKeepalivePubSub,
 		getNodeStatsConfig,
+		getMeshConfig,
+		mesh.NewMesh,
 		routing.CreateRouter,
 	)
 
@@ -268,4 +273,8 @@ func newInProcessTurnServer(conf *config.Config, authHandler turn.AuthHandler) (
 
 func getNodeStatsConfig(config *config.Config) config.NodeStatsConfig {
 	return config.NodeStats
+}
+
+func getMeshConfig(config *config.Config) config.MeshConfig {
+	return config.Mesh
 }

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"github.com/livekit/livekit-server/pkg/agent"
 	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/mesh"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/telemetry"
@@ -60,7 +61,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		return nil, err
 	}
 	nodeStatsConfig := getNodeStatsConfig(conf)
-	router := routing.CreateRouter(universalClient, currentNode, signalClient, roomManagerClient, keepalivePubSub, nodeStatsConfig)
+	router := routing.CreateRouter(universalClient, currentNode, signalClient, roomManagerClient, keepalivePubSub, nodeStatsConfig, conf.Mesh, mesh.NewMesh())
 	objectStore := createStore(universalClient)
 	roomAllocator, err := NewRoomAllocator(conf, router, objectStore)
 	if err != nil {
@@ -184,7 +185,7 @@ func InitializeRouter(conf *config.Config, currentNode routing.LocalNode) (routi
 		return nil, err
 	}
 	nodeStatsConfig := getNodeStatsConfig(conf)
-	router := routing.CreateRouter(universalClient, currentNode, signalClient, roomManagerClient, keepalivePubSub, nodeStatsConfig)
+	router := routing.CreateRouter(universalClient, currentNode, signalClient, roomManagerClient, keepalivePubSub, nodeStatsConfig, conf.Mesh, mesh.NewMesh())
 	return router, nil
 }
 


### PR DESCRIPTION
## Summary
- add simple mesh registry implementation
- support MeshRouter with a new mesh config
- wire mesh creation in server initialization
- document mesh option in sample config

## Testing
- `go test ./... -run TestMeshAddList -count=1` *(fails: module downloads forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a648d274c8327b94c00c6b1715ee9