### PR TITLE
Fix mesh relay compilation

### DIFF
--- a/pkg/sfu/mesh/message.go
+++ b/pkg/sfu/mesh/message.go
@@ -1,0 +1,48 @@
+package mesh
+
+import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+)
+
+// RelayMessage wraps RTP or RTCP data for forwarding via psrpc.
+type RelayMessage struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Packet  []byte   `protobuf:"bytes,1,opt,name=packet,proto3"`
+	Packets [][]byte `protobuf:"bytes,2,rep,name=packets,proto3"`
+}
+
+func (x *RelayMessage) Reset()         { *x = RelayMessage{} }
+func (x *RelayMessage) String() string { return protoimpl.X.MessageStringOf(x) }
+func (*RelayMessage) ProtoMessage()    {}
+func (x *RelayMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_livekit_sfu_mesh_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var file_livekit_sfu_mesh_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+
+func init() {
+	file_livekit_sfu_mesh_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+		switch v := v.(*RelayMessage); i {
+		case 0:
+			return &v.state
+		case 1:
+			return &v.sizeCache
+		case 2:
+			return &v.unknownFields
+		default:
+			return nil
+		}
+	}
+}

--- a/pkg/sfu/mesh/receiver.go
+++ b/pkg/sfu/mesh/receiver.go
@@ -12,7 +12,7 @@ import (
 
 // Receiver consumes RTP/RTCP from a remote node via a psrpc stream.
 type Receiver struct {
-	stream psrpc.Stream[*RTPMessage, *RTCPMessage]
+	stream psrpc.Stream[*RelayMessage, *RelayMessage]
 	logger logger.Logger
 	mu     sync.Mutex
 
@@ -20,7 +20,7 @@ type Receiver struct {
 	OnRTCP func([]rtcp.Packet)
 }
 
-func NewReceiver(stream psrpc.Stream[*RTPMessage, *RTCPMessage], l logger.Logger) *Receiver {
+func NewReceiver(stream psrpc.Stream[*RelayMessage, *RelayMessage], l logger.Logger) *Receiver {
 	r := &Receiver{stream: stream, logger: l}
 	go r.read()
 	return r
@@ -28,7 +28,7 @@ func NewReceiver(stream psrpc.Stream[*RTPMessage, *RTCPMessage], l logger.Logger
 
 func (r *Receiver) read() {
 	for msg := range r.stream.Channel() {
-		if msg.Packets != nil { // RTCP
+		if len(msg.Packets) > 0 {
 			pkts := make([]rtcp.Packet, 0, len(msg.Packets))
 			for _, b := range msg.Packets {
 				ps, err := rtcp.Unmarshal(b)
@@ -41,7 +41,7 @@ func (r *Receiver) read() {
 			}
 			continue
 		}
-		if msg.Packet != nil {
+		if len(msg.Packet) > 0 {
 			pkt := &rtp.Packet{}
 			if err := pkt.Unmarshal(msg.Packet); err == nil {
 				if r.OnRTP != nil {

--- a/pkg/sfu/mesh/relay.go
+++ b/pkg/sfu/mesh/relay.go
@@ -10,24 +10,14 @@ import (
 	"github.com/livekit/psrpc"
 )
 
-// RTPMessage is a minimal wrapper for forwarding RTP packets via psrpc.
-type RTPMessage struct {
-	Packet []byte
-}
-
-// RTCPMessage wraps a batch of RTCP packets for forwarding.
-type RTCPMessage struct {
-	Packets [][]byte
-}
-
 // Relay forwards media to a remote SFU node using psrpc streams.
 type Relay struct {
-	stream psrpc.Stream[*RTPMessage, *RTCPMessage]
+	stream psrpc.Stream[*RelayMessage, *RelayMessage]
 	logger logger.Logger
 	mu     sync.Mutex
 }
 
-func NewRelay(stream psrpc.Stream[*RTPMessage, *RTCPMessage], l logger.Logger) *Relay {
+func NewRelay(stream psrpc.Stream[*RelayMessage, *RelayMessage], l logger.Logger) *Relay {
 	return &Relay{stream: stream, logger: l}
 }
 
@@ -40,7 +30,7 @@ func (r *Relay) ForwardRTP(pkt *rtp.Packet) error {
 	if err != nil {
 		return err
 	}
-	return r.stream.Send(&RTPMessage{Packet: b})
+	return r.stream.Send(&RelayMessage{Packet: b})
 }
 
 // ForwardRTCP forwards RTCP packets to the remote node.
@@ -56,7 +46,7 @@ func (r *Relay) ForwardRTCP(pkts []rtcp.Packet) error {
 		}
 		data = append(data, b)
 	}
-	return r.stream.Send(&RTCPMessage{Packets: data})
+	return r.stream.Send(&RelayMessage{Packets: data})
 }
 
 // Close terminates the underlying psrpc stream.


### PR DESCRIPTION
## Summary
- add `RelayMessage` protobuf compatible type for mesh relays
- update `Relay` and `Receiver` to use `RelayMessage`

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a6a67e030832799c3534833848093